### PR TITLE
only trigger errors if requested

### DIFF
--- a/src/StreamWrapper.php
+++ b/src/StreamWrapper.php
@@ -747,7 +747,10 @@ class StreamWrapper {
 				return $this->trigger_error( $e->getMessage() );
 			}
 		} catch ( Throwable $e ) {
-			return $this->trigger_error( $e->getMessage() );
+			// The API will request a file and not expect it to exist
+			if ( ! ($flags & STREAM_URL_STAT_QUIET) ) {
+				return $this->trigger_error( $e->getMessage() );
+			}
 		}
 
 		return false;


### PR DESCRIPTION
If disable asserts is true, a different exception is thrown and we should only trigger an error if the wrapper requested it not to be silent.

- https://flysystem.thephpleague.com/v1/docs/advanced/performance/
- https://www.php.net/manual/en/streamwrapper.url-stat.php